### PR TITLE
Histogram: modify Clear() to return snapshot of previous histo

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const(
+const (
 	histogram_pool_size = 300000
 )
 


### PR DESCRIPTION
This is the same thing we did with the Timer. It allows us to reset histograms every time we send metrics to graphite.
Before these changes you can see that we keep histogram values across metric readings:
![image](https://user-images.githubusercontent.com/602409/29130823-d421b56e-7cdf-11e7-8ad2-ac48eed7131d.png)
