### PR TITLE
[ch25899] Add Clear() method that returns snapshot to counter

### DIFF
--- a/counter_test.go
+++ b/counter_test.go
@@ -13,9 +13,12 @@ func BenchmarkCounter(b *testing.B) {
 func TestCounterClear(t *testing.T) {
 	c := NewCounter()
 	c.Inc(1)
-	c.Clear()
+	old := c.Clear()
 	if count := c.Count(); 0 != count {
 		t.Errorf("c.Count(): 0 != %v\n", count)
+	}
+	if count := old.Count(); 1 != count {
+		t.Errorf("c.Count(): 1 != %v\n", count)
 	}
 }
 

--- a/timer.go
+++ b/timer.go
@@ -80,7 +80,7 @@ type NilTimer struct {
 
 // Clear is a no-op.
 func (NilTimer) Clear() Timer {
-	return nil
+	return &NilTimer{}
 }
 
 // Count is a no-op.

--- a/timer.go
+++ b/timer.go
@@ -80,7 +80,7 @@ type NilTimer struct {
 
 // Clear is a no-op.
 func (NilTimer) Clear() Timer {
-	return &NilTimer{}
+	return nil
 }
 
 // Count is a no-op.


### PR DESCRIPTION
This allows us to snapshot counters at intervals and aggregate them using the
same method as counters for timers and histograms.