### PR TITLE
Add float64 histogram

### DIFF
--- a/histogram_float64.go
+++ b/histogram_float64.go
@@ -1,0 +1,211 @@
+package metrics
+
+import "sync"
+
+// Histograms calculate distribution statistics from a series of float64 values.
+type HistogramFloat64 interface {
+	Clear() HistogramFloat64 // atomically clears and returns a snapshot
+	Count() int64
+	Max() float64
+	Mean() float64
+	Min() float64
+	Percentile(float64) float64
+	Percentiles([]float64) []float64
+	Sample() SampleFloat64
+	Snapshot() HistogramFloat64
+	StdDev() float64
+	Sum() float64
+	Update(float64)
+	Variance() float64
+}
+
+// GetOrRegisterHistogram returns an existing Histogram or constructs and
+// registers a new StandardHistogramFloat64.
+func GetOrRegisterHistogramFloat64(name string, r Registry, s SampleFloat64) HistogramFloat64 {
+	if nil == r {
+		r = DefaultRegistry
+	}
+	return r.GetOrRegister(name, func() HistogramFloat64 { return NewHistogramFloat64(s) }).(HistogramFloat64)
+}
+
+// NewHistogram constructs a new StandardHistogramFloat64 from a Sample.
+func NewHistogramFloat64(s SampleFloat64) HistogramFloat64 {
+	if UseNilMetrics {
+		return NilHistogramFloat64{}
+	}
+	return &StandardHistogramFloat64{sample: s}
+}
+
+// NewRegisteredHistogram constructs and registers a new StandardHistogramFloat64 from
+// a Sample.
+func NewRegisteredHistogramFloat64(name string, r Registry, s SampleFloat64) HistogramFloat64 {
+	c := NewHistogramFloat64(s)
+	if nil == r {
+		r = DefaultRegistry
+	}
+	r.Register(name, c)
+	return c
+}
+
+// HistogramSnapshotFloat64 is a read-only copy of another Histogram.
+type HistogramSnapshotFloat64 struct {
+	sample *SampleFloat64Snapshot
+}
+
+// Clear panics.
+func (*HistogramSnapshotFloat64) Clear() HistogramFloat64 {
+	panic("Clear called on a HistogramSnapshotFloat64")
+}
+
+// Count returns the number of samples recorded at the time the snapshot was
+// taken.
+func (h *HistogramSnapshotFloat64) Count() int64 { return h.sample.Count() }
+
+// Max returns the maximum value in the sample at the time the snapshot was
+// taken.
+func (h *HistogramSnapshotFloat64) Max() float64 { return h.sample.Max() }
+
+// Mean returns the mean of the values in the sample at the time the snapshot
+// was taken.
+func (h *HistogramSnapshotFloat64) Mean() float64 { return h.sample.Mean() }
+
+// Min returns the minimum value in the sample at the time the snapshot was
+// taken.
+func (h *HistogramSnapshotFloat64) Min() float64 { return h.sample.Min() }
+
+// Percentile returns an arbitrary percentile of values in the sample at the
+// time the snapshot was taken.
+func (h *HistogramSnapshotFloat64) Percentile(p float64) float64 {
+	return h.sample.Percentile(p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of values in the sample
+// at the time the snapshot was taken.
+func (h *HistogramSnapshotFloat64) Percentiles(ps []float64) []float64 {
+	return h.sample.Percentiles(ps)
+}
+
+// Sample returns the Sample underlying the histogram.
+func (h *HistogramSnapshotFloat64) Sample() SampleFloat64 { return h.sample }
+
+// Snapshot returns the snapshot.
+func (h *HistogramSnapshotFloat64) Snapshot() HistogramFloat64 { return h }
+
+// StdDev returns the standard deviation of the values in the sample at the
+// time the snapshot was taken.
+func (h *HistogramSnapshotFloat64) StdDev() float64 { return h.sample.StdDev() }
+
+// Sum returns the sum in the sample at the time the snapshot was taken.
+func (h *HistogramSnapshotFloat64) Sum() float64 { return h.sample.Sum() }
+
+// Update panics.
+func (*HistogramSnapshotFloat64) Update(float64) {
+	panic("Update called on a HistogramSnapshotFloat64")
+}
+
+// Variance returns the variance of inputs at the time the snapshot was taken.
+func (h *HistogramSnapshotFloat64) Variance() float64 { return h.sample.Variance() }
+
+// NilHistogramFloat64 is a no-op Histogram.
+type NilHistogramFloat64 struct{}
+
+// Clear is a no-op.
+func (NilHistogramFloat64) Clear() HistogramFloat64 { return NilHistogramFloat64{} }
+
+// Count is a no-op.
+func (NilHistogramFloat64) Count() int64 { return 0 }
+
+// Max is a no-op.
+func (NilHistogramFloat64) Max() float64 { return 0 }
+
+// Mean is a no-op.
+func (NilHistogramFloat64) Mean() float64 { return 0.0 }
+
+// Min is a no-op.
+func (NilHistogramFloat64) Min() float64 { return 0 }
+
+// Percentile is a no-op.
+func (NilHistogramFloat64) Percentile(p float64) float64 { return 0.0 }
+
+// Percentiles is a no-op.
+func (NilHistogramFloat64) Percentiles(ps []float64) []float64 {
+	return make([]float64, len(ps))
+}
+
+// Sample is a no-op.
+func (NilHistogramFloat64) Sample() SampleFloat64 { return NilSampleFloat64{} }
+
+// Snapshot is a no-op.
+func (NilHistogramFloat64) Snapshot() HistogramFloat64 { return NilHistogramFloat64{} }
+
+// StdDev is a no-op.
+func (NilHistogramFloat64) StdDev() float64 { return 0.0 }
+
+// Sum is a no-op.
+func (NilHistogramFloat64) Sum() float64 { return 0 }
+
+// Update is a no-op.
+func (NilHistogramFloat64) Update(v float64) {}
+
+// Variance is a no-op.
+func (NilHistogramFloat64) Variance() float64 { return 0.0 }
+
+// StandardHistogramFloat64 is the standard implementation of a Histogram and uses a
+// Sample to bound its memory use.
+type StandardHistogramFloat64 struct {
+	sample SampleFloat64
+	mutex  sync.Mutex
+}
+
+// Clear clears the histogram and its sample.
+func (h *StandardHistogramFloat64) Clear() HistogramFloat64 {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	hSnap := &HistogramSnapshotFloat64{sample: h.sample.Snapshot().(*SampleFloat64Snapshot)}
+	h.sample.Clear()
+	return hSnap
+}
+
+// Count returns the number of samples recorded since the histogram was last
+// cleared.
+func (h *StandardHistogramFloat64) Count() int64 { return h.sample.Count() }
+
+// Max returns the maximum value in the sample.
+func (h *StandardHistogramFloat64) Max() float64 { return h.sample.Max() }
+
+// Mean returns the mean of the values in the sample.
+func (h *StandardHistogramFloat64) Mean() float64 { return h.sample.Mean() }
+
+// Min returns the minimum value in the sample.
+func (h *StandardHistogramFloat64) Min() float64 { return h.sample.Min() }
+
+// Percentile returns an arbitrary percentile of the values in the sample.
+func (h *StandardHistogramFloat64) Percentile(p float64) float64 {
+	return h.sample.Percentile(p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of the values in the
+// sample.
+func (h *StandardHistogramFloat64) Percentiles(ps []float64) []float64 {
+	return h.sample.Percentiles(ps)
+}
+
+// Sample returns the Sample underlying the histogram.
+func (h *StandardHistogramFloat64) Sample() SampleFloat64 { return h.sample }
+
+// Snapshot returns a read-only copy of the histogram.
+func (h *StandardHistogramFloat64) Snapshot() HistogramFloat64 {
+	return &HistogramSnapshotFloat64{sample: h.sample.Snapshot().(*SampleFloat64Snapshot)}
+}
+
+// StdDev returns the standard deviation of the values in the sample.
+func (h *StandardHistogramFloat64) StdDev() float64 { return h.sample.StdDev() }
+
+// Sum returns the sum in the sample.
+func (h *StandardHistogramFloat64) Sum() float64 { return h.sample.Sum() }
+
+// Update samples a new value.
+func (h *StandardHistogramFloat64) Update(v float64) { h.sample.Update(v) }
+
+// Variance returns the variance of the values in the sample.
+func (h *StandardHistogramFloat64) Variance() float64 { return h.sample.Variance() }

--- a/histogram_float64_test.go
+++ b/histogram_float64_test.go
@@ -1,0 +1,95 @@
+package metrics
+
+import "testing"
+
+func BenchmarkHistogramFloat64(b *testing.B) {
+	h := NewHistogramFloat64(NewUniformSampleFloat64(100))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.Update(float64(i))
+	}
+}
+
+func TestGetOrRegisterHistogramFloat64(t *testing.T) {
+	r := NewRegistry()
+	s := NewUniformSampleFloat64(100)
+	NewRegisteredHistogramFloat64("foo", r, s).Update(47)
+	if h := GetOrRegisterHistogramFloat64("foo", r, s); 1 != h.Count() {
+		t.Fatal(h)
+	}
+}
+
+func TestHistogramFloat6410000(t *testing.T) {
+	h := NewHistogramFloat64(NewUniformSampleFloat64(100000))
+	for i := 1; i <= 10000; i++ {
+		h.Update(float64(i))
+	}
+	testHistogramFloat6410000(t, h)
+}
+
+func TestHistogramFloat64Empty(t *testing.T) {
+	h := NewHistogramFloat64(NewUniformSampleFloat64(100))
+	if count := h.Count(); 0 != count {
+		t.Errorf("h.Count(): 0 != %v\n", count)
+	}
+	if min := h.Min(); 0 != min {
+		t.Errorf("h.Min(): 0 != %v\n", min)
+	}
+	if max := h.Max(); 0 != max {
+		t.Errorf("h.Max(): 0 != %v\n", max)
+	}
+	if mean := h.Mean(); 0.0 != mean {
+		t.Errorf("h.Mean(): 0.0 != %v\n", mean)
+	}
+	if stdDev := h.StdDev(); 0.0 != stdDev {
+		t.Errorf("h.StdDev(): 0.0 != %v\n", stdDev)
+	}
+	ps := h.Percentiles([]float64{0.5, 0.75, 0.99})
+	if 0.0 != ps[0] {
+		t.Errorf("median: 0.0 != %v\n", ps[0])
+	}
+	if 0.0 != ps[1] {
+		t.Errorf("75th percentile: 0.0 != %v\n", ps[1])
+	}
+	if 0.0 != ps[2] {
+		t.Errorf("99th percentile: 0.0 != %v\n", ps[2])
+	}
+}
+
+func TestHistogramFloat64Snapshot(t *testing.T) {
+	h := NewHistogramFloat64(NewUniformSampleFloat64(100000))
+	for i := 1; i <= 10000; i++ {
+		h.Update(float64(i))
+	}
+	snapshot := h.Snapshot()
+	h.Update(0)
+	testHistogramFloat6410000(t, snapshot)
+}
+
+func testHistogramFloat6410000(t *testing.T, h HistogramFloat64) {
+	if count := h.Count(); 10000 != count {
+		t.Errorf("h.Count(): 10000 != %v\n", count)
+	}
+	if min := h.Min(); 1 != min {
+		t.Errorf("h.Min(): 1 != %v\n", min)
+	}
+	if max := h.Max(); 10000 != max {
+		t.Errorf("h.Max(): 10000 != %v\n", max)
+	}
+	if mean := h.Mean(); 5000.5 != mean {
+		t.Errorf("h.Mean(): 5000.5 != %v\n", mean)
+	}
+	if stdDev := h.StdDev(); 2886.751331514372 != stdDev {
+		t.Errorf("h.StdDev(): 2886.751331514372 != %v\n", stdDev)
+	}
+	ps := h.Percentiles([]float64{0.5, 0.75, 0.99})
+	if 5000.5 != ps[0] {
+		t.Errorf("median: 5000.5 != %v\n", ps[0])
+	}
+	if 7500.75 != ps[1] {
+		t.Errorf("75th percentile: 7500.75 != %v\n", ps[1])
+	}
+	if 9900.99 != ps[2] {
+		t.Errorf("99th percentile: 9900.99 != %v\n", ps[2])
+	}
+}

--- a/sample_float64.go
+++ b/sample_float64.go
@@ -1,0 +1,615 @@
+package metrics
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+)
+
+// SampleFloat64s maintain a statistically-significant selection of values from
+// a stream.
+type SampleFloat64 interface {
+	Clear()
+	Count() int64
+	Max() float64
+	Mean() float64
+	Min() float64
+	Percentile(float64) float64
+	Percentiles([]float64) []float64
+	Size() int
+	Snapshot() SampleFloat64
+	StdDev() float64
+	Sum() float64
+	Update(float64)
+	Values() []float64
+	Variance() float64
+}
+
+// ExpDecaySampleFloat64 is an exponentially-decaying SampleFloat64 using a forward-decaying
+// priority reservoir.  See Cormode et al's "Forward Decay: A Practical Time
+// Decay Model for Streaming Systems".
+//
+// <http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf>
+type ExpDecaySampleFloat64 struct {
+	alpha         float64
+	count         int64
+	mutex         sync.Mutex
+	reservoirSize int
+	t0, t1        time.Time
+	values        *expDecaySampleFloat64Heap
+}
+
+// NewExpDecaySampleFloat64 constructs a new exponentially-decaying SampleFloat64 with the
+// given reservoir size and alpha.
+func NewExpDecaySampleFloat64(reservoirSize int, alpha float64) SampleFloat64 {
+	if UseNilMetrics {
+		return NilSampleFloat64{}
+	}
+	s := &ExpDecaySampleFloat64{
+		alpha:         alpha,
+		reservoirSize: reservoirSize,
+		t0:            time.Now(),
+		values:        newExpDecaySampleFloat64Heap(reservoirSize),
+	}
+	s.t1 = s.t0.Add(rescaleThreshold)
+	return s
+}
+
+// Clear clears all SampleFloat64s.
+func (s *ExpDecaySampleFloat64) Clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.count = 0
+	s.t0 = time.Now()
+	s.t1 = s.t0.Add(rescaleThreshold)
+	s.values.Clear()
+}
+
+// Count returns the number of SampleFloat64s recorded, which may exceed the
+// reservoir size.
+func (s *ExpDecaySampleFloat64) Count() int64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.count
+}
+
+// Max returns the maximum value in the SampleFloat64, which may not be the maximum
+// value ever to be part of the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Max() float64 {
+	return SampleFloat64Max(s.Values())
+}
+
+// Mean returns the mean of the values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Mean() float64 {
+	return SampleFloat64Mean(s.Values())
+}
+
+// Min returns the minimum value in the SampleFloat64, which may not be the minimum
+// value ever to be part of the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Min() float64 {
+	return SampleFloat64Min(s.Values())
+}
+
+// Percentile returns an arbitrary percentile of values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Percentile(p float64) float64 {
+	return SampleFloat64Percentile(s.Values(), p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of values in the
+// SampleFloat64.
+func (s *ExpDecaySampleFloat64) Percentiles(ps []float64) []float64 {
+	return SampleFloat64Percentiles(s.Values(), ps)
+}
+
+// Size returns the size of the SampleFloat64, which is at most the reservoir size.
+func (s *ExpDecaySampleFloat64) Size() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.values.Size()
+}
+
+// Snapshot returns a read-only copy of the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Snapshot() SampleFloat64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	vals := s.values.Values()
+	values := make([]float64, len(vals))
+	for i, v := range vals {
+		values[i] = v.v
+	}
+	return &SampleFloat64Snapshot{
+		count:  s.count,
+		values: values,
+	}
+}
+
+// StdDev returns the standard deviation of the values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) StdDev() float64 {
+	return SampleFloat64StdDev(s.Values())
+}
+
+// Sum returns the sum of the values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Sum() float64 {
+	return SampleFloat64Sum(s.Values())
+}
+
+// Update SampleFloat64s a new value.
+func (s *ExpDecaySampleFloat64) Update(v float64) {
+	s.update(time.Now(), v)
+}
+
+// Values returns a copy of the values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Values() []float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	vals := s.values.Values()
+	values := make([]float64, len(vals))
+	for i, v := range vals {
+		values[i] = v.v
+	}
+	return values
+}
+
+// Variance returns the variance of the values in the SampleFloat64.
+func (s *ExpDecaySampleFloat64) Variance() float64 {
+	return SampleFloat64Variance(s.Values())
+}
+
+// update SampleFloat64s a new value at a particular timestamp.  This is a method all
+// its own to facilitate testing.
+func (s *ExpDecaySampleFloat64) update(t time.Time, v float64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.count++
+	if s.values.Size() == s.reservoirSize {
+		s.values.Pop()
+	}
+	s.values.Push(expDecaySampleFloat64{
+		k: math.Exp(t.Sub(s.t0).Seconds()*s.alpha) / rand.Float64(),
+		v: v,
+	})
+	if t.After(s.t1) {
+		values := s.values.Values()
+		t0 := s.t0
+		s.values.Clear()
+		s.t0 = t
+		s.t1 = s.t0.Add(rescaleThreshold)
+		for _, v := range values {
+			v.k = v.k * math.Exp(-s.alpha*s.t0.Sub(t0).Seconds())
+			s.values.Push(v)
+		}
+	}
+}
+
+// NilSampleFloat64 is a no-op SampleFloat64.
+type NilSampleFloat64 struct{}
+
+// Clear is a no-op.
+func (NilSampleFloat64) Clear() {}
+
+// Count is a no-op.
+func (NilSampleFloat64) Count() int64 { return 0 }
+
+// Max is a no-op.
+func (NilSampleFloat64) Max() float64 { return 0 }
+
+// Mean is a no-op.
+func (NilSampleFloat64) Mean() float64 { return 0.0 }
+
+// Min is a no-op.
+func (NilSampleFloat64) Min() float64 { return 0 }
+
+// Percentile is a no-op.
+func (NilSampleFloat64) Percentile(p float64) float64 { return 0.0 }
+
+// Percentiles is a no-op.
+func (NilSampleFloat64) Percentiles(ps []float64) []float64 {
+	return make([]float64, len(ps))
+}
+
+// Size is a no-op.
+func (NilSampleFloat64) Size() int { return 0 }
+
+// SampleFloat64 is a no-op.
+func (NilSampleFloat64) Snapshot() SampleFloat64 { return NilSampleFloat64{} }
+
+// StdDev is a no-op.
+func (NilSampleFloat64) StdDev() float64 { return 0.0 }
+
+// Sum is a no-op.
+func (NilSampleFloat64) Sum() float64 { return 0 }
+
+// Update is a no-op.
+func (NilSampleFloat64) Update(v float64) {}
+
+// Values is a no-op.
+func (NilSampleFloat64) Values() []float64 { return []float64{} }
+
+// Variance is a no-op.
+func (NilSampleFloat64) Variance() float64 { return 0.0 }
+
+// SampleFloat64Max returns the maximum value of the slice of float64.
+func SampleFloat64Max(values []float64) float64 {
+	if 0 == len(values) {
+		return 0
+	}
+	var max float64 = math.MaxFloat64 * -1
+	for _, v := range values {
+		if max < v {
+			max = v
+		}
+	}
+	return max
+}
+
+// SampleFloat64Mean returns the mean value of the slice of float64.
+func SampleFloat64Mean(values []float64) float64 {
+	if 0 == len(values) {
+		return 0.0
+	}
+	return float64(SampleFloat64Sum(values)) / float64(len(values))
+}
+
+// SampleFloat64Min returns the minimum value of the slice of int64.
+func SampleFloat64Min(values []float64) float64 {
+	if 0 == len(values) {
+		return 0
+	}
+	var min float64 = math.MaxFloat64
+	for _, v := range values {
+		if min > v {
+			min = v
+		}
+	}
+	return min
+}
+
+// SampleFloat64Percentiles returns an arbitrary percentile of the slice of
+// float64.
+func SampleFloat64Percentile(values float64Slice, p float64) float64 {
+	return SampleFloat64Percentiles(values, []float64{p})[0]
+}
+
+// SampleFloat64Percentiles returns a slice of arbitrary percentiles of the slice of
+// float64.
+func SampleFloat64Percentiles(values float64Slice, ps []float64) []float64 {
+	scores := make([]float64, len(ps))
+	size := len(values)
+	if size > 0 {
+		sort.Sort(values)
+		for i, p := range ps {
+			pos := p * float64(size+1)
+			if pos < 1.0 {
+				scores[i] = float64(values[0])
+			} else if pos >= float64(size) {
+				scores[i] = float64(values[size-1])
+			} else {
+				lower := float64(values[int(pos)-1])
+				upper := float64(values[int(pos)])
+				scores[i] = lower + (pos-math.Floor(pos))*(upper-lower)
+			}
+		}
+	}
+	return scores
+}
+
+// SampleFloat64Snapshot is a read-only copy of another SampleFloat64.
+type SampleFloat64Snapshot struct {
+	count  int64
+	values []float64
+}
+
+func NewSampleFloat64Snapshot(count int64, values []float64) *SampleFloat64Snapshot {
+	return &SampleFloat64Snapshot{
+		count:  count,
+		values: values,
+	}
+}
+
+// Clear panics.
+func (*SampleFloat64Snapshot) Clear() {
+	panic("Clear called on a SampleFloat64Snapshot")
+}
+
+// Count returns the count of inputs at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Count() int64 { return s.count }
+
+// Max returns the maximal value at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Max() float64 { return SampleFloat64Max(s.values) }
+
+// Mean returns the mean value at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Mean() float64 { return SampleFloat64Mean(s.values) }
+
+// Min returns the minimal value at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Min() float64 { return SampleFloat64Min(s.values) }
+
+// Percentile returns an arbitrary percentile of values at the time the
+// snapshot was taken.
+func (s *SampleFloat64Snapshot) Percentile(p float64) float64 {
+	return SampleFloat64Percentile(s.values, p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of values at the time
+// the snapshot was taken.
+func (s *SampleFloat64Snapshot) Percentiles(ps []float64) []float64 {
+	return SampleFloat64Percentiles(s.values, ps)
+}
+
+// Size returns the size of the SampleFloat64 at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Size() int { return len(s.values) }
+
+// Snapshot returns the snapshot.
+func (s *SampleFloat64Snapshot) Snapshot() SampleFloat64 { return s }
+
+// StdDev returns the standard deviation of values at the time the snapshot was
+// taken.
+func (s *SampleFloat64Snapshot) StdDev() float64 { return SampleFloat64StdDev(s.values) }
+
+// Sum returns the sum of values at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Sum() float64 { return SampleFloat64Sum(s.values) }
+
+// Update panics.
+func (*SampleFloat64Snapshot) Update(float64) {
+	panic("Update called on a SampleFloat64Snapshot")
+}
+
+// Values returns a copy of the values in the SampleFloat64.
+func (s *SampleFloat64Snapshot) Values() []float64 {
+	values := make([]float64, len(s.values))
+	copy(values, s.values)
+	return values
+}
+
+// Variance returns the variance of values at the time the snapshot was taken.
+func (s *SampleFloat64Snapshot) Variance() float64 { return SampleFloat64Variance(s.values) }
+
+// SampleFloat64StdDev returns the standard deviation of the slice of float64.
+func SampleFloat64StdDev(values []float64) float64 {
+	return math.Sqrt(SampleFloat64Variance(values))
+}
+
+// SampleFloat64Sum returns the sum of the slice of float64.
+func SampleFloat64Sum(values []float64) float64 {
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	return sum
+}
+
+// SampleFloat64Variance returns the variance of the slice of float64.
+func SampleFloat64Variance(values []float64) float64 {
+	if 0 == len(values) {
+		return 0.0
+	}
+	m := SampleFloat64Mean(values)
+	var sum float64
+	for _, v := range values {
+		d := float64(v) - m
+		sum += d * d
+	}
+	return sum / float64(len(values))
+}
+
+// A uniform SampleFloat64 using Vitter's Algorithm R.
+//
+// <http://www.cs.umd.edu/~samir/498/vitter.pdf>
+type UniformSampleFloat64 struct {
+	count         int64
+	mutex         sync.Mutex
+	reservoirSize int
+	values        []float64
+}
+
+// NewUniformSampleFloat64 constructs a new uniform SampleFloat64 with the given reservoir
+// size.
+func NewUniformSampleFloat64(reservoirSize int) SampleFloat64 {
+	if UseNilMetrics {
+		return NilSampleFloat64{}
+	}
+	return &UniformSampleFloat64{
+		reservoirSize: reservoirSize,
+		values:        make([]float64, 0, reservoirSize),
+	}
+}
+
+// Clear clears all SampleFloat64s.
+func (s *UniformSampleFloat64) Clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.count = 0
+	s.values = make([]float64, 0, s.reservoirSize)
+}
+
+// Count returns the number of SampleFloat64s recorded, which may exceed the
+// reservoir size.
+func (s *UniformSampleFloat64) Count() int64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.count
+}
+
+// Max returns the maximum value in the SampleFloat64, which may not be the maximum
+// value ever to be part of the SampleFloat64.
+func (s *UniformSampleFloat64) Max() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Max(s.values)
+}
+
+// Mean returns the mean of the values in the SampleFloat64.
+func (s *UniformSampleFloat64) Mean() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Mean(s.values)
+}
+
+// Min returns the minimum value in the SampleFloat64, which may not be the minimum
+// value ever to be part of the SampleFloat64.
+func (s *UniformSampleFloat64) Min() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Min(s.values)
+}
+
+// Percentile returns an arbitrary percentile of values in the SampleFloat64.
+func (s *UniformSampleFloat64) Percentile(p float64) float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Percentile(s.values, p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of values in the
+// SampleFloat64.
+func (s *UniformSampleFloat64) Percentiles(ps []float64) []float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Percentiles(s.values, ps)
+}
+
+// Size returns the size of the SampleFloat64, which is at most the reservoir size.
+func (s *UniformSampleFloat64) Size() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return len(s.values)
+}
+
+// Snapshot returns a read-only copy of the SampleFloat64.
+func (s *UniformSampleFloat64) Snapshot() SampleFloat64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	values := make([]float64, len(s.values))
+	copy(values, s.values)
+	return &SampleFloat64Snapshot{
+		count:  s.count,
+		values: values,
+	}
+}
+
+// StdDev returns the standard deviation of the values in the SampleFloat64.
+func (s *UniformSampleFloat64) StdDev() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64StdDev(s.values)
+}
+
+// Sum returns the sum of the values in the SampleFloat64.
+func (s *UniformSampleFloat64) Sum() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Sum(s.values)
+}
+
+// Update SampleFloat64s a new value.
+func (s *UniformSampleFloat64) Update(v float64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.count++
+	if len(s.values) < s.reservoirSize {
+		s.values = append(s.values, v)
+	} else {
+		r := rand.Int63n(s.count)
+		if r < int64(len(s.values)) {
+			s.values[int(r)] = v
+		}
+	}
+}
+
+// Values returns a copy of the values in the SampleFloat64.
+func (s *UniformSampleFloat64) Values() []float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	values := make([]float64, len(s.values))
+	copy(values, s.values)
+	return values
+}
+
+// Variance returns the variance of the values in the SampleFloat64.
+func (s *UniformSampleFloat64) Variance() float64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return SampleFloat64Variance(s.values)
+}
+
+// expDecaySampleFloat64 represents an individual SampleFloat64 in a heap.
+type expDecaySampleFloat64 struct {
+	k float64
+	v float64
+}
+
+func newExpDecaySampleFloat64Heap(reservoirSize int) *expDecaySampleFloat64Heap {
+	return &expDecaySampleFloat64Heap{make([]expDecaySampleFloat64, 0, reservoirSize)}
+}
+
+// expDecaySampleFloat64Heap is a min-heap of expDecaySampleFloat64s.
+// The internal implementation is copied from the standard library's container/heap
+type expDecaySampleFloat64Heap struct {
+	s []expDecaySampleFloat64
+}
+
+func (h *expDecaySampleFloat64Heap) Clear() {
+	h.s = h.s[:0]
+}
+
+func (h *expDecaySampleFloat64Heap) Push(s expDecaySampleFloat64) {
+	n := len(h.s)
+	h.s = h.s[0 : n+1]
+	h.s[n] = s
+	h.up(n)
+}
+
+func (h *expDecaySampleFloat64Heap) Pop() expDecaySampleFloat64 {
+	n := len(h.s) - 1
+	h.s[0], h.s[n] = h.s[n], h.s[0]
+	h.down(0, n)
+
+	n = len(h.s)
+	s := h.s[n-1]
+	h.s = h.s[0 : n-1]
+	return s
+}
+
+func (h *expDecaySampleFloat64Heap) Size() int {
+	return len(h.s)
+}
+
+func (h *expDecaySampleFloat64Heap) Values() []expDecaySampleFloat64 {
+	return h.s
+}
+
+func (h *expDecaySampleFloat64Heap) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !(h.s[j].k < h.s[i].k) {
+			break
+		}
+		h.s[i], h.s[j] = h.s[j], h.s[i]
+		j = i
+	}
+}
+
+func (h *expDecaySampleFloat64Heap) down(i, n int) {
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && !(h.s[j1].k < h.s[j2].k) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !(h.s[j].k < h.s[i].k) {
+			break
+		}
+		h.s[i], h.s[j] = h.s[j], h.s[i]
+		i = j
+	}
+}
+
+type float64Slice []float64
+
+func (p float64Slice) Len() int           { return len(p) }
+func (p float64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p float64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/sample_float64_test.go
+++ b/sample_float64_test.go
@@ -1,0 +1,316 @@
+package metrics
+
+import (
+	"math/rand"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func BenchmarkExpDecaySampleFloat64Float64257(b *testing.B) {
+	benchmarkSampleFloat64(b, NewExpDecaySampleFloat64(257, 0.015))
+}
+
+func BenchmarkExpDecaySampleFloat64Float64514(b *testing.B) {
+	benchmarkSampleFloat64(b, NewExpDecaySampleFloat64(514, 0.015))
+}
+
+func BenchmarkExpDecaySampleFloat64Float641028(b *testing.B) {
+	benchmarkSampleFloat64(b, NewExpDecaySampleFloat64(1028, 0.015))
+}
+
+func BenchmarkUniformSampleFloat64257(b *testing.B) {
+	benchmarkSampleFloat64(b, NewUniformSampleFloat64(257))
+}
+
+func BenchmarkUniformSampleFloat64514(b *testing.B) {
+	benchmarkSampleFloat64(b, NewUniformSampleFloat64(514))
+}
+
+func BenchmarkUniformSampleFloat641028(b *testing.B) {
+	benchmarkSampleFloat64(b, NewUniformSampleFloat64(1028))
+}
+
+func TestExpDecaySampleFloat6410(t *testing.T) {
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(100, 0.99)
+	for i := 0; i < 10; i++ {
+		s.Update(float64(i))
+	}
+	if size := s.Count(); 10 != size {
+		t.Errorf("s.Count(): 10 != %v\n", size)
+	}
+	if size := s.Size(); 10 != size {
+		t.Errorf("s.Size(): 10 != %v\n", size)
+	}
+	if l := len(s.Values()); 10 != l {
+		t.Errorf("len(s.Values()): 10 != %v\n", l)
+	}
+	for _, v := range s.Values() {
+		if v > 10 || v < 0 {
+			t.Errorf("out of range [0, 10): %v\n", v)
+		}
+	}
+}
+
+func TestExpDecaySampleFloat64100(t *testing.T) {
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(1000, 0.01)
+	for i := 0; i < 100; i++ {
+		s.Update(float64(i))
+	}
+	if size := s.Count(); 100 != size {
+		t.Errorf("s.Count(): 100 != %v\n", size)
+	}
+	if size := s.Size(); 100 != size {
+		t.Errorf("s.Size(): 100 != %v\n", size)
+	}
+	if l := len(s.Values()); 100 != l {
+		t.Errorf("len(s.Values()): 100 != %v\n", l)
+	}
+	for _, v := range s.Values() {
+		if v > 100 || v < 0 {
+			t.Errorf("out of range [0, 100): %v\n", v)
+		}
+	}
+}
+
+func TestExpDecaySampleFloat641000(t *testing.T) {
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(100, 0.99)
+	for i := 0; i < 1000; i++ {
+		s.Update(float64(i))
+	}
+	if size := s.Count(); 1000 != size {
+		t.Errorf("s.Count(): 1000 != %v\n", size)
+	}
+	if size := s.Size(); 100 != size {
+		t.Errorf("s.Size(): 100 != %v\n", size)
+	}
+	if l := len(s.Values()); 100 != l {
+		t.Errorf("len(s.Values()): 100 != %v\n", l)
+	}
+	for _, v := range s.Values() {
+		if v > 1000 || v < 0 {
+			t.Errorf("out of range [0, 1000): %v\n", v)
+		}
+	}
+}
+
+// This test makes sure that the sample's priority is not amplified by using
+// nanosecond duration since start rather than second duration since start.
+// The priority becomes +Inf quickly after starting if this is done,
+// effectively freezing the set of samples until a rescale step happens.
+func TestExpDecaySampleFloat64NanosecondRegression(t *testing.T) {
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(100, 0.99)
+	for i := 0; i < 100; i++ {
+		s.Update(10)
+	}
+	time.Sleep(1 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		s.Update(20)
+	}
+	v := s.Values()
+	avg := float64(0)
+	for i := 0; i < len(v); i++ {
+		avg += float64(v[i])
+	}
+	avg /= float64(len(v))
+	if avg > 16 || avg < 14 {
+		t.Errorf("out of range [14, 16]: %v\n", avg)
+	}
+}
+
+func TestExpDecaySampleFloat64Rescale(t *testing.T) {
+	s := NewExpDecaySampleFloat64(2, 0.001).(*ExpDecaySampleFloat64)
+	s.update(time.Now(), 1)
+	s.update(time.Now().Add(time.Hour+time.Microsecond), 1)
+	for _, v := range s.values.Values() {
+		if v.k == 0.0 {
+			t.Fatal("v.k == 0.0")
+		}
+	}
+}
+
+func TestExpDecaySampleFloat64Snapshot(t *testing.T) {
+	now := time.Now()
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(100, 0.99)
+	for i := 1; i <= 10000; i++ {
+		s.(*ExpDecaySampleFloat64).update(now.Add(time.Duration(i)), float64(i))
+	}
+	snapshot := s.Snapshot()
+	s.Update(1)
+	testExpDecaySampleFloat64Statistics(t, snapshot)
+}
+
+func TestExpDecaySampleFloat64Statistics(t *testing.T) {
+	now := time.Now()
+	rand.Seed(1)
+	s := NewExpDecaySampleFloat64(100, 0.99)
+	for i := 1; i <= 10000; i++ {
+		s.(*ExpDecaySampleFloat64).update(now.Add(time.Duration(i)), float64(i))
+	}
+	testExpDecaySampleFloat64Statistics(t, s)
+}
+
+func TestUniformSampleFloat64(t *testing.T) {
+	rand.Seed(1)
+	s := NewUniformSampleFloat64(100)
+	for i := 0; i < 1000; i++ {
+		s.Update(float64(i))
+	}
+	if size := s.Count(); 1000 != size {
+		t.Errorf("s.Count(): 1000 != %v\n", size)
+	}
+	if size := s.Size(); 100 != size {
+		t.Errorf("s.Size(): 100 != %v\n", size)
+	}
+	if l := len(s.Values()); 100 != l {
+		t.Errorf("len(s.Values()): 100 != %v\n", l)
+	}
+	for _, v := range s.Values() {
+		if v > 1000 || v < 0 {
+			t.Errorf("out of range [0, 100): %v\n", v)
+		}
+	}
+}
+
+func TestUniformSampleFloat64IncludesTail(t *testing.T) {
+	rand.Seed(1)
+	s := NewUniformSampleFloat64(100)
+	max := 100
+	for i := 0; i < max; i++ {
+		s.Update(float64(i))
+	}
+	v := s.Values()
+	sum := 0
+	exp := (max - 1) * max / 2
+	for i := 0; i < len(v); i++ {
+		sum += int(v[i])
+	}
+	if exp != sum {
+		t.Errorf("sum: %v != %v\n", exp, sum)
+	}
+}
+
+func TestUniformSampleFloat64Snapshot(t *testing.T) {
+	s := NewUniformSampleFloat64(100)
+	for i := 1; i <= 10000; i++ {
+		s.Update(float64(i))
+	}
+	snapshot := s.Snapshot()
+	s.Update(1)
+	testUniformSampleFloat64Statistics(t, snapshot)
+}
+
+func TestUniformSampleFloat64Statistics(t *testing.T) {
+	rand.Seed(1)
+	s := NewUniformSampleFloat64(100)
+	for i := 1; i <= 10000; i++ {
+		s.Update(float64(i))
+	}
+	testUniformSampleFloat64Statistics(t, s)
+}
+
+func benchmarkSampleFloat64(b *testing.B, s SampleFloat64) {
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	pauseTotalNs := memStats.PauseTotalNs
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Update(1)
+	}
+	b.StopTimer()
+	runtime.GC()
+	runtime.ReadMemStats(&memStats)
+	b.Logf("GC cost: %d ns/op", int(memStats.PauseTotalNs-pauseTotalNs)/b.N)
+}
+
+func testExpDecaySampleFloat64Statistics(t *testing.T, s SampleFloat64) {
+	if count := s.Count(); 10000 != count {
+		t.Errorf("s.Count(): 10000 != %v\n", count)
+	}
+	if min := s.Min(); 107 != min {
+		t.Errorf("s.Min(): 107 != %v\n", min)
+	}
+	if max := s.Max(); 10000 != max {
+		t.Errorf("s.Max(): 10000 != %v\n", max)
+	}
+	if mean := s.Mean(); 4965.98 != mean {
+		t.Errorf("s.Mean(): 4965.98 != %v\n", mean)
+	}
+	if stdDev := s.StdDev(); 2959.825156930727 != stdDev {
+		t.Errorf("s.StdDev(): 2959.825156930727 != %v\n", stdDev)
+	}
+	ps := s.Percentiles([]float64{0.5, 0.75, 0.99})
+	if 4615 != ps[0] {
+		t.Errorf("median: 4615 != %v\n", ps[0])
+	}
+	if 7672 != ps[1] {
+		t.Errorf("75th percentile: 7672 != %v\n", ps[1])
+	}
+	if 9998.99 != ps[2] {
+		t.Errorf("99th percentile: 9998.99 != %v\n", ps[2])
+	}
+}
+
+func testUniformSampleFloat64Statistics(t *testing.T, s SampleFloat64) {
+	if count := s.Count(); 10000 != count {
+		t.Errorf("s.Count(): 10000 != %v\n", count)
+	}
+	if min := s.Min(); 37 != min {
+		t.Errorf("s.Min(): 37 != %v\n", min)
+	}
+	if max := s.Max(); 9989 != max {
+		t.Errorf("s.Max(): 9989 != %v\n", max)
+	}
+	if mean := s.Mean(); 4748.14 != mean {
+		t.Errorf("s.Mean(): 4748.14 != %v\n", mean)
+	}
+	if stdDev := s.StdDev(); 2826.684117548333 != stdDev {
+		t.Errorf("s.StdDev(): 2826.684117548333 != %v\n", stdDev)
+	}
+	ps := s.Percentiles([]float64{0.5, 0.75, 0.99})
+	if 4599 != ps[0] {
+		t.Errorf("median: 4599 != %v\n", ps[0])
+	}
+	if 7380.5 != ps[1] {
+		t.Errorf("75th percentile: 7380.5 != %v\n", ps[1])
+	}
+	if 9986.429999999998 != ps[2] {
+		t.Errorf("99th percentile: 9986.429999999998 != %v\n", ps[2])
+	}
+}
+
+// TestUniformSampleFloat64ConcurrentUpdateCount would expose data race problems with
+// concurrent Update and Count calls on Sample when test is called with -race
+// argument
+func TestUniformSampleFloat64ConcurrentUpdateCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	s := NewUniformSampleFloat64(100)
+	for i := 0; i < 100; i++ {
+		s.Update(float64(i))
+	}
+	quit := make(chan struct{})
+	go func() {
+		t := time.NewTicker(10 * time.Millisecond)
+		for {
+			select {
+			case <-t.C:
+				s.Update(rand.Float64())
+			case <-quit:
+				t.Stop()
+				return
+			}
+		}
+	}()
+	for i := 0; i < 1000; i++ {
+		s.Count()
+		time.Sleep(5 * time.Millisecond)
+	}
+	quit <- struct{}{}
+}


### PR DESCRIPTION
Adds support for a histogram which contains `float64` values.

Pulled into `foundation` to validate use case with datadog reporter. Will need to merge to test with a live application